### PR TITLE
Handling other plugin unloading better

### DIFF
--- a/src/main/java/com/mallowigi/icons/TintedIconsComponent.java
+++ b/src/main/java/com/mallowigi/icons/TintedIconsComponent.java
@@ -29,6 +29,7 @@ import com.intellij.ide.plugins.DynamicPluginListener;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.ui.LafManagerListener;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.ui.ColorUtil;
@@ -51,6 +52,7 @@ import java.net.URL;
  * Apply a tint to the icons. This is used either for accented icons and themed icons.
  */
 public final class TintedIconsComponent implements DynamicPluginListener, AppLifecycleListener, DumbAware {
+  private static final PluginId PLUGIN_ID = PluginId.getId("com.mallowigi");
   private TintedColorPatcher colorPatcher;
   private final MessageBusConnection connect;
 
@@ -75,6 +77,8 @@ public final class TintedIconsComponent implements DynamicPluginListener, AppLif
 
   @Override
   public void pluginUnloaded(@NotNull final IdeaPluginDescriptor pluginDescriptor, final boolean isUpdate) {
+    if(!PLUGIN_ID.equals(pluginDescriptor.getPluginId())) return;
+
     disposeComponent();
   }
 


### PR DESCRIPTION
# Changes

- Checking to see if plugin that is being unloaded is this plugin, before disposing component

# Motivation

This listener hears all of the plugins being unloaded, so if a user uninstalls any other dynamic plugin, the tinter looses config updates until restart.