### PR TITLE
Supporting other SVG Color Patchers

### DIFF
--- a/src/main/java/com/mallowigi/icons/SvgLoaderHacker.kt
+++ b/src/main/java/com/mallowigi/icons/SvgLoaderHacker.kt
@@ -1,0 +1,43 @@
+package com.mallowigi.icons
+
+import com.intellij.util.SVGLoader
+import java.net.URL
+import java.util.Optional
+
+typealias PatcherProvider = SVGLoader.SvgElementColorPatcherProvider
+
+object SvgLoaderHacker {
+
+  private lateinit var collectedPatcherProvider: PatcherProvider
+
+  @JvmStatic
+  fun collectOtherPatcher(): PatcherProvider =
+    extractPatcher()
+      .filter { it is PatcherProvider }
+      .filter { it !is TintedIconsComponent.TintedColorPatcher }
+      .map {
+        val otherPatcher = it as PatcherProvider
+        collectedPatcherProvider = otherPatcher
+        otherPatcher
+      }
+      .orElseGet { useFallBackPatcher() }
+
+  private fun extractPatcher() = Optional.ofNullable(
+    SVGLoader::class.java.declaredFields
+      .firstOrNull { it.name == "ourColorPatcher" }
+  )
+    .map { ourColorPatcherField ->
+      ourColorPatcherField.isAccessible = true
+      ourColorPatcherField.get(null)
+    }
+
+
+  private val noOpPatcherProvider =
+    object : PatcherProvider {
+      override fun forURL(url: URL?): SVGLoader.SvgElementColorPatcher? = null
+    }
+
+  private fun useFallBackPatcher(): PatcherProvider =
+    if (this::collectedPatcherProvider.isInitialized) collectedPatcherProvider
+    else noOpPatcherProvider
+}


### PR DESCRIPTION
# Changes
- Forcefully extracting the other set color patcher to be used in the SVG color patching process.
- Removed deprecated `forURL` method because this version supports 2021+

# Motivation

Allows the UITheme patcher (which changes the default icon's colors) and any other patcher to do their work too. Closes #161 


# Things I tested

**Used Plugin Settings**

![Screenshot from 2021-04-15 05-20-49](https://user-images.githubusercontent.com/15972415/114857432-ddbd3600-9dad-11eb-8122-6790683aebe9.png)


**Results**
 
| Before | After |
| --- | --- |
| ![Screenshot from 2021-04-15 05-22-47](https://user-images.githubusercontent.com/15972415/114857506-f4638d00-9dad-11eb-90de-8d17a3fbc530.png) | ![Screenshot from 2021-04-15 05-20-26](https://user-images.githubusercontent.com/15972415/114857525-f9c0d780-9dad-11eb-8f1c-c03c9a469437.png) |

So before these changes, this plugin's patcher took priority, so the UITheme pacther (which changes the colors of the default JetBrain's icons) and my theme's patcher (which changes the kotlin/space/other icons) where being discarded. Now it's patchers all the way down, and things that should be themed, get themed. (I have this same code in the plugins that I maintain too.)

I also made sure that updates to this plugin's colors would be applied on settings update.


