### PR TITLE
Support folder/ file path matching if the pattern contains forward slash

### DIFF
--- a/common/src/main/java/com/mallowigi/icons/associations/RegexAssociation.kt
+++ b/common/src/main/java/com/mallowigi/icons/associations/RegexAssociation.kt
@@ -69,7 +69,11 @@ class RegexAssociation internal constructor() : Association() {
   override fun matches(file: FileInfo): Boolean {
     return try {
       if (compiledPattern == null) compiledPattern = Pattern.compile(pattern, Pattern.CASE_INSENSITIVE)
-      compiledPattern!!.matcher(file.name).matches()
+      var target = file.name
+      if (pattern.contains("/")) {
+        target = file.path
+      }
+      compiledPattern!!.matcher(target).matches()
     } catch (e: PatternSyntaxException) {
       LOG.warn(e)
       false

--- a/common/src/main/java/com/mallowigi/models/FileInfo.kt
+++ b/common/src/main/java/com/mallowigi/models/FileInfo.kt
@@ -32,4 +32,7 @@ interface FileInfo {
   /** File name. */
   val name: String
 
+  /** Full path of File. */
+  val path: String
+
 }

--- a/common/src/main/java/com/mallowigi/models/VirtualFileInfo.kt
+++ b/common/src/main/java/com/mallowigi/models/VirtualFileInfo.kt
@@ -38,4 +38,6 @@ class VirtualFileInfo(private val vFile: VirtualFile) : FileInfo {
   override val fileType: String
     get() = vFile.fileType.name
 
+  override val path: String
+    get() = vFile.getPath()
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## Changelog
 
 ----
+## 81.0.0 (8.1.0)
+
+### Features
+
+- Support folder/ file path matching if the pattern contains forward slash
 
 ## 80.0.0 (8.0.0)
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Added `path` field to `VirtualFileInfo`. It is used while matching file/ folder association pattern, if the pattern contains forward slash `/`.


#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Allows to set folder icons relative to parent folder in languages where parent folder provides special meaning such as golang, rust etc. See the screenshots below

<!-- If it fixes an open issue, please link to the issue here. -->

#### Screenshots (if appropriate):

**Icons for subfolders**
![relative_folder_association](https://user-images.githubusercontent.com/10169201/206797631-36f88e40-ab49-4244-8013-2715552b4875.jpg)

**Setting used to set icons relative to parent folder**
![relative_folder_association_settings](https://user-images.githubusercontent.com/10169201/206797826-c82e6b38-e315-4ede-8565-be9037c00c62.jpg)

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] ~~Bug fix (non-breaking change which fixes an issue)~~
- [x] New feature (non-breaking change which adds functionality)
- [ ] ~~Breaking change (fix or feature that would cause existing functionality to change)~~
- [ ] ~~Non-Functional Change (non-user facing changes)~~

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
- [x] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [x] I updated the version.
- [x] I updated the changelog with the new functionality.
